### PR TITLE
Add DS_Store to ignored files in gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,4 @@
 /tmp
 /coverage/
 .env
+.DS_Store


### PR DESCRIPTION
DS Store files were showing up in our git commits. This will ignore them.