### PR TITLE
Bugfix swap comments ratings requirement

### DIFF
--- a/app/models/review.rb
+++ b/app/models/review.rb
@@ -2,10 +2,8 @@ class Review < ActiveRecord::Base
   belongs_to :user
   belongs_to :venue
 
-  validates :rating, allow_blank: true,
-                     allow_nil: true,
+  validates :rating, presence: true,
                      numericality: { only_integer: true,
                                      greater_than_or_equal_to: 1,
                                      less_than_or_equal_to: 5 }
-  validates :body, presence: true
 end

--- a/db/migrate/20160708193848_switch_ratings_comments_required_on_reviews.rb
+++ b/db/migrate/20160708193848_switch_ratings_comments_required_on_reviews.rb
@@ -1,0 +1,11 @@
+class SwitchRatingsCommentsRequiredOnReviews < ActiveRecord::Migration
+  def up
+    change_column :reviews, :body, :text, null: true
+    change_column :reviews, :rating, :integer, null: false
+  end
+
+  def down
+    change_column :reviews, :body, :text, null: false
+    change_column :reviews, :rating, :integer, null: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,14 +11,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20160708144348) do
+ActiveRecord::Schema.define(version: 20160708193848) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
   create_table "reviews", force: :cascade do |t|
-    t.integer "rating"
-    t.text    "body",     null: false
+    t.integer "rating",   null: false
+    t.text    "body"
     t.integer "user_id"
     t.integer "venue_id"
   end
@@ -57,8 +57,8 @@ ActiveRecord::Schema.define(version: 20160708144348) do
   end
 
   create_table "votes", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "review_id"
+    t.integer "user_id",   null: false
+    t.integer "review_id", null: false
     t.string  "vote_type", null: false
   end
 

--- a/spec/models/review_spec.rb
+++ b/spec/models/review_spec.rb
@@ -1,11 +1,8 @@
 require 'rails_helper'
 
 describe Review, type: :model do
-  it { should have_valid(:rating).when(1, 2, 3, 4, 5, '', nil) }
-  it { should_not have_valid(:rating).when(0, 6, 10, 'abd', 'a') }
-
-  it { should have_valid(:body).when('this is a review') }
-  it { should_not have_valid(:body).when('', nil) }
+  it { should have_valid(:rating).when(1, 2, 3, 4, 5) }
+  it { should_not have_valid(:rating).when(0, 6, 10, 'abd', 'a', '', nil) }
 
   it { should belong_to(:user) }
 


### PR DESCRIPTION
BUGFIX: Rating should be required, comments should be optional. 
This fixes a bug in the model, model tests, and has a migration to update null requirements on the database.

Feature specs are being addressed in another PR.