### PR TITLE
Update flash template using F6 instead of F5

### DIFF
--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,4 +1,5 @@
 <% flash.each do |type, message| %>
+  <% type = 'success' if type == 'notice' %>
   <div class="callout <%= type %>" data-closable>
     <%= message %>
     <button class="close-button" aria-label="Dismiss alert" type="button" data-close>

--- a/app/views/application/_flash.html.erb
+++ b/app/views/application/_flash.html.erb
@@ -1,6 +1,8 @@
 <% flash.each do |type, message| %>
-  <div data-alert class="alert-box <%= type %> radius">
+  <div class="callout <%= type %>" data-closable>
     <%= message %>
-    <a href="#" class="close">&times;</a>
+    <button class="close-button" aria-label="Dismiss alert" type="button" data-close>
+      <span aria-hidden="true">&times;</span>
+    </button>
   </div>
 <% end %>


### PR DESCRIPTION
Another small change I noticed when working on a side project and using this project as a reference. Looks like we made the flash templates according to the Foundation 5 docs, but foundation-rails uses Foundation 6, which doesn't include an 'alert' class. Switched it to use the correct callout class for better formatting of flash messages.