### PR TITLE
Updating development.rb to get rid of deprecation warning

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -43,5 +43,5 @@ Rails.application.configure do
   config.action_mailer.default_url_options = { host: 'localhost', port: 3000}
 
   # Serve static files in dev
-  config.serve_static_assets = true
+  config.serve_static_files = true
 end


### PR DESCRIPTION
Updated config/environments/development.rb.  The serve_static_assets function we were using won't work in rails 5, so I've updated it for future proofing.