### PR TITLE
Hr at delete users

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,2 +1,7 @@
 class UsersController < ApplicationController
+  before_action :authenticate_user!
+
+  def show
+    @user = User.find(params[:format])
+  end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -62,8 +62,8 @@ ActiveRecord::Schema.define(version: 20160712200950) do
   add_index "venues", ["user_id"], name: "index_venues_on_user_id", using: :btree
 
   create_table "votes", force: :cascade do |t|
-    t.integer "user_id"
-    t.integer "review_id"
+    t.integer "user_id",   null: false
+    t.integer "review_id", null: false
     t.string  "vote_type", null: false
   end
 

--- a/spec/features/user_can_delete_account_spec.rb
+++ b/spec/features/user_can_delete_account_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+feature 'Delete a user' do
+  let(:user) { FactoryGirl.create(:user) }
+
+  scenario 'User deletes their account' do
+    login_user(user)
+    visit edit_user_registration_path(user.id)
+
+    click_button('Cancel my account')
+
+    expect(page).not_to have_content(user.username)
+    expect(page).to have_content('Your account has been successfully cancelled. We hope to see you again soon.')
+  end
+
+  scenario 'Unauthenticated user' do
+    visit edit_user_registration_path(user)
+
+    expect(page).not_to have_button('Cancel my account')
+  end
+end

--- a/spec/features/user_can_delete_account_spec.rb
+++ b/spec/features/user_can_delete_account_spec.rb
@@ -10,7 +10,8 @@ feature 'Delete a user' do
     click_button('Cancel my account')
 
     expect(page).not_to have_content(user.username)
-    expect(page).to have_content('Your account has been successfully cancelled. We hope to see you again soon.')
+    expect(page).to have_content('Your account has been successfully
+                                 cancelled.')
   end
 
   scenario 'Unauthenticated user' do


### PR DESCRIPTION
This PR contains tests for deleting a user. This functionality comes bundled with devise.  We're trusting their authentication here, which we may want to customize, but we know the path of user sign in > edit > delete works.