### PR TITLE
users can now alter their own reviews

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -17,6 +17,8 @@ class ReviewsController < ApplicationController
     @review = Review.new(review_params)
     @venue = Venue.find(params[:venue_id])
     @review.venue = @venue
+    @review.user_id = current_user.id
+
     if @review.save
       flash[:notice] = 'Review added successfully'
       send_email(@review, @venue)


### PR DESCRIPTION
This PR fixes a bug where the edit and delete buttons never appeared for non admins because we did not assign a user id to a review when it was created.