### PR TITLE
Fix edit form so that the correct radio button is selected on load

### DIFF
--- a/app/views/venues/_form.html.erb
+++ b/app/views/venues/_form.html.erb
@@ -17,8 +17,7 @@
   <%= f.label :t_accessible %>
 
   <%= f.radio_button :t_accessible, false,
-                     id: 't_not_accessible',
-                     checked: true %>
+                     id: 't_not_accessible' %>
   <%= f.label :t_not_accessible %><br/>
 
   <%= f.submit 'Save Venue', class: 'button' %>

--- a/spec/features/venues/update_venue_spec.rb
+++ b/spec/features/venues/update_venue_spec.rb
@@ -48,4 +48,22 @@ feature 'Update a venue' do
                                  'continuing')
     expect(current_path).to eq(new_user_session_path)
   end
+
+  scenario 't is accesible is selected if true on venue' do
+    venue = FactoryGirl.create(:venue, user: admin, t_accessible: true)
+
+    visit edit_venue_path(venue)
+
+    expect(find("#t_accessible")).to be_checked
+    expect(find("#t_not_accessible")).not_to be_checked
+  end
+
+  scenario 't not accesible is selected if false on venue' do
+    venue = FactoryGirl.create(:venue, user: admin, t_accessible: false)
+
+    visit edit_venue_path(venue)
+
+    expect(find("#t_not_accessible")).to be_checked
+    expect(find("#t_accessible")).not_to be_checked
+  end
 end


### PR DESCRIPTION
This is a small bug fix. Originally, when visiting the edit page for a venue, it would always be false. Now the edit form will select whichever is the case for the current venue.