### PR TITLE
Bugfix admin delete users

### DIFF
--- a/app/controllers/admin_users_controller.rb
+++ b/app/controllers/admin_users_controller.rb
@@ -1,7 +1,14 @@
 class AdminUsersController < ApplicationController
   before_action :authorize_user
+
   def index
     @admin_users = User.all
+  end
+
+  def destroy
+    User.destroy(params[:id])
+    flash[:success] = 'User deleted'
+    redirect_to admin_users_path
   end
 
   def authorize_user

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,10 +1,6 @@
 class UsersController < ApplicationController
   before_action :authorize_user, except: :show
-  before_action :authenticate_user!, except: :index
-
-  def index
-    @admin_users = User.all
-  end
+  before_action :authenticate_user!
 
   def show
     @user = User.find(params[:format])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,9 +1,9 @@
 class User < ActiveRecord::Base
   mount_uploader :avatar, AvatarUploader
 
-  has_many :venues
-  has_many :reviews
-  has_many :votes
+  has_many :venues, dependent: :destroy
+  has_many :reviews, dependent: :destroy
+  has_many :votes, dependent: :destroy
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/app/views/admin_users/index.html.erb
+++ b/app/views/admin_users/index.html.erb
@@ -1,0 +1,10 @@
+<ul>
+  <% @admin_users.each do |user| %>
+    <li><%= user.username %></li>
+    <ul class="button-group">
+      <li class="delete-button"><%= button_to 'Delete User', admin_user_path(user), data: {confirm: 'Are you sure?' },
+      method: :delete, class: 'button tertiery' %>
+      </li>
+    </ul>
+  <% end %>
+</ul>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -25,7 +25,7 @@
             <%= link_to "#{current_user.username}", edit_user_registration_path(@user)%>
           </li>
           <% if current_user.admin? %>
-            <li><%= link_to "Admin Section", admin_users_path(current_user.id) %></li>
+            <li><%= link_to "Admin Section", admin_users_path %></li>
           <% end %>
           <li>
             <%= link_to 'Sign Out', destroy_user_session_path, class: 'button', method: 'delete' %>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,5 +1,0 @@
-<ul>
-  <% @admin_users.each do |user| %>
-    <li><%= user.username %></li>
-  <% end %>
-</ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,9 +5,7 @@ Rails.application.routes.draw do
 
   resources :homepage, only: [:index]
 
-  resources :admin do
-    resources :users, only: [:index]
-  end
+  resources :admin_users, only: [:index, :destroy]
 
   namespace :api do
     resources :reviews, only: [:index] do

--- a/spec/features/admin/admin_deletes_user_spec.rb
+++ b/spec/features/admin/admin_deletes_user_spec.rb
@@ -1,20 +1,18 @@
 require 'rails_helper'
 
-feature 'Admin views all venues' do
-  scenario 'When admin visits page sees all users.' do
-    users = FactoryGirl.create_list(:user, 3)
+feature 'Admin deletes a user' do
+  scenario 'Admin deletes a user' do
+    user = FactoryGirl.create(:user)
     admin = FactoryGirl.create(:user, role: "admin")
 
     login_user(admin)
     visit root_path
+
     click_link 'Admin Section'
+    first('.delete-button').click_button('Delete User')
 
-    users.each do |user|
-      expect(page).to have_content(user.username)
-      expect(page).to have_content(admin.username)
-    end
-
-
+    expect(page).to have_content('User deleted')
+    expect{ User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   scenario 'Non-admin is rejected from viewing user index' do

--- a/spec/features/admin/admin_deletes_user_spec.rb
+++ b/spec/features/admin/admin_deletes_user_spec.rb
@@ -12,7 +12,7 @@ feature 'Admin deletes a user' do
     first('.delete-button').click_button('Delete User')
 
     expect(page).to have_content('User deleted')
-    expect{ User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
+    expect { User.find(user.id) }.to raise_error(ActiveRecord::RecordNotFound)
   end
 
   scenario 'Non-admin is rejected from viewing user index' do

--- a/spec/features/admin/admin_sees_all_users_spec.rb
+++ b/spec/features/admin/admin_sees_all_users_spec.rb
@@ -13,8 +13,6 @@ feature 'Admin views all venues' do
       expect(page).to have_content(user.username)
       expect(page).to have_content(admin.username)
     end
-
-
   end
 
   scenario 'Non-admin is rejected from viewing user index' do


### PR DESCRIPTION
This PR adds the ability for admins to delete users, and tests for same.  As a consequence, deleting a user will delete *all* their data. Including venues, reviews, and votes.