### PR TITLE
Shorten review for tweet

### DIFF
--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -86,7 +86,7 @@ class ReviewsController < ApplicationController
   def send_tweet(review, venue)
     unless review.body.empty?
       twitter = TwitterService.new
-      twitter.send_tweet("Review: #{venue.name}: "\
+      twitter.send_tweet("Review: #{venue.short_name}: "\
                          "#{review.short_body} #{venue_url(venue)}")
     end
   end

--- a/app/controllers/reviews_controller.rb
+++ b/app/controllers/reviews_controller.rb
@@ -26,7 +26,7 @@ class ReviewsController < ApplicationController
       send_tweet(@review, @venue)
       redirect_to venue_path(@venue)
     else
-      flash[:error] = 'Problem saving review.'
+      flash[:alert] = 'Problem saving review.'
       @errors = @review.errors.full_messages
       render :new
     end
@@ -43,7 +43,7 @@ class ReviewsController < ApplicationController
       flash[:success] = 'Review saved successfully'
       redirect_to venue_path(@review.venue)
     else
-      flash[:error] = 'Problem saving review.'
+      flash[:alert] = 'Problem saving review.'
       render :edit
     end
   end
@@ -86,7 +86,7 @@ class ReviewsController < ApplicationController
   def send_tweet(review, venue)
     unless review.body.empty?
       twitter = TwitterService.new
-      twitter.send_tweet("New Review for #{venue.name}: "\
+      twitter.send_tweet("Review: #{venue.name}: "\
                          "#{review.short_body} #{venue_url(venue)}")
     end
   end

--- a/app/models/venue.rb
+++ b/app/models/venue.rb
@@ -24,4 +24,10 @@ class Venue < ActiveRecord::Base
       'No nearby T station'
     end
   end
+
+  def short_name
+    max = 20
+    temp_name = name
+    temp_name.length > max ? "#{temp_name[0..max].strip}..." : temp_name
+  end
 end

--- a/spec/models/venue_spec.rb
+++ b/spec/models/venue_spec.rb
@@ -35,4 +35,18 @@ describe Venue, type: :model do
       expect(text).to eq('No nearby T station')
     end
   end
+
+  describe '#short_name' do
+    it "keeps short names the same" do
+      venue = FactoryGirl.create(:venue, name: 'Short Name')
+
+      expect(venue.short_name).to eq(venue.name)
+    end
+
+    it "shortens long venue names" do
+      venue = FactoryGirl.create(:venue, name: 'This Is A Venue Music Hall')
+
+      expect(venue.short_name).to eq('This Is A Venue Music...')
+    end
+  end
 end


### PR DESCRIPTION
This fixes a bug with long review names. It also fixes some error messages that weren't formatted correctly.